### PR TITLE
Fixed arbitrary code execution on Zapata

### DIFF
--- a/misc/create_dummy_dataset.py
+++ b/misc/create_dummy_dataset.py
@@ -3,7 +3,7 @@ import yaml, os, sys
 import numpy as np
 
 # import dummy_dataset from catalogue
-catalogue = yaml.load(open('../zapata/catalogue.yml'), Loader=yaml.FullLoader)
+catalogue = yaml.load(open('../zapata/catalogue.yml'), Loader=yaml.SafeLoader)
 
 dataset = catalogue['dummy_dataset']
 

--- a/zapata/data.py
+++ b/zapata/data.py
@@ -103,12 +103,12 @@ def inquire_catalogue(dataset=None, info=False):
     pwd = os.path.dirname(os.path.abspath(__file__))
 
     # Load catalogue
-    catalogue = yaml.load(open(pwd + '/catalogue.yml'), Loader=yaml.FullLoader)
+    catalogue = yaml.load(open(pwd + '/catalogue.yml'), Loader=yaml.SafeLoader)
  
     # if user defined catalogue exists, update generale one
     user_catalogue = pwd + '/../user_catalogue.yml'
     if os.path.isfile(user_catalogue):
-       tmp_dict = yaml.load(open(user_catalogue), Loader=yaml.FullLoader)
+       tmp_dict = yaml.load(open(user_catalogue), Loader=yaml.SafeLoader)
        if (tmp_dict is not None):
           catalogue.update(tmp_dict)
           print('Append user defined lists of datasets to catalogue:\n')


### PR DESCRIPTION
### 📊 Metadata *

Insecure YAML deserialization
#### Bounty URL:  https://www.huntr.dev/bounties/1-other-Zapata

### ⚙️ Description *

`Zapata` is a Computational and Mapping Library. This package is vulnerable to `Arbitrary Code Execution`

### 💻 Technical Description *

Vulnerable to YAML deserialization attack caused by unsafe loading.

### 🐛 Proof of Concept (PoC) *

`python3 exp.py`
```python3
from zapata.data import inquire_catalogue
inquire_catalogue()
```
add this to `user_catalogue.yaml`
```yaml
payload = """cmd: !!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
"""
```

![image](https://user-images.githubusercontent.com/16708391/108763053-e136fc80-7576-11eb-8646-305a397d0118.png)


### 🔥 Proof of Fix (PoF) *

Used a safer loader(SafeLoader) instead of `FullLoader`.

The issue is fixed, and hence no code is executed.


### 👍 User Acceptance Testing (UAT)

All Ok, No breaking changes introduced.  :)